### PR TITLE
NPE check to avoid crashes

### DIFF
--- a/android/src/main/java/com/bradbumbalough/RCTTwilioChat/RCTTwilioChatClient.java
+++ b/android/src/main/java/com/bradbumbalough/RCTTwilioChat/RCTTwilioChatClient.java
@@ -234,7 +234,10 @@ public class RCTTwilioChatClient extends ReactContextBaseJavaModule implements C
     @ReactMethod
     public void shutdown() {
         RCTTwilioChatClient tmp = RCTTwilioChatClient.getInstance();
-        if (tmp.client != null) tmp.client.shutdown();
+        if (tmp.client != null) {
+          tmp.client.shutdown();
+          tmp.client = null;
+        }
     }
 
     @ReactMethod

--- a/android/src/main/java/com/bradbumbalough/RCTTwilioChat/RCTTwilioChatClient.java
+++ b/android/src/main/java/com/bradbumbalough/RCTTwilioChat/RCTTwilioChatClient.java
@@ -234,7 +234,7 @@ public class RCTTwilioChatClient extends ReactContextBaseJavaModule implements C
     @ReactMethod
     public void shutdown() {
         RCTTwilioChatClient tmp = RCTTwilioChatClient.getInstance();
-        tmp.client.shutdown();
+        if (tmp.client != null) tmp.client.shutdown();
     }
 
     @ReactMethod


### PR DESCRIPTION
The NPE causes a lot of crashes in our app. Although we had JS check to avoid shutting down un-initialized client as follow:

* create client
```js
    let clientInitialised = false;

    client.initialize().then(() => {
      clientInitialised = true;
      accessManager.registerClient();
    }).catch((error) => {
      console.log(error);
    });
```
* shutdown client
```is
if (client && clientInitialised) {
   client.shutdown();
}
```

But it seems there are still some edge cases we don't cover and it's hard to reproduce in our test env. So we decided to add this nice-to-have NP check before shutting the client in Java code. 



