### PR TITLE
Remove createJSModules @Override declaration

### DIFF
--- a/android/src/main/java/com/bradbumbalough/RCTTwilioChat/RCTTwilioChatPackage.java
+++ b/android/src/main/java/com/bradbumbalough/RCTTwilioChat/RCTTwilioChatPackage.java
@@ -12,7 +12,6 @@ import java.util.List;
 
 
 public class RCTTwilioChatPackage implements ReactPackage {
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Hi! On recent react-native versions [it's no longer necessary to declare which JS modules are exposed on a package](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8). This means that the `@Override` declaration over createJSModules now throws an error on build. This PR removes the declaration. This change makes it incompatible with older react-native versions, so if another release is made the package version should be updated accordingly.